### PR TITLE
Added extra_host for missing elasticsearch

### DIFF
--- a/docker/conf/docker-compose.prod.yml.dist
+++ b/docker/conf/docker-compose.prod.yml.dist
@@ -26,6 +26,7 @@ services:
         extra_hosts:
             - postgres:192.168.0.1
             - redis:192.168.0.1
+            - elasticsearch:192.168.0.1
         networks:
             - shopsys-network
 


### PR DESCRIPTION
I had problem with building docker for production, and this solved my troubles with connectiong to elasticsearch.